### PR TITLE
Update package.json to the correct url

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/netsells/vuex-rest-api-cache.git"
+    "url": "https://github.com/netsells/vue-with-prop-proxy.git"
   },
   "jest": {
     "moduleNameMapper": {


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2Fpatch-1)](https://netsells.atlassian.net/browse/patch-1)

When clicking to the package through via github, it sends you to the wrong repo. I believe this is due to this url value being wrong. Have updated it to go to the right place